### PR TITLE
Add ability to parse list of PR data for PRs that was created by a specified user!

### DIFF
--- a/myapp/client/src/App.js
+++ b/myapp/client/src/App.js
@@ -88,12 +88,39 @@ class App extends Component {
 
   }
 
-  /* 
-   * reports a list of PR
+  /* parse an array of json objects describing PR from github based on a condition
+   * returns an array of json objects based on condition
    */
-  reportPRList() {
+  parseGithubPRJson( githubPRJsonSet, condition, key ) {
+    var parsedPRSet = [];
+
+    if( condition === 'byName' ) {
+      parsedPRSet = githubPRJsonSet.filter( eachElement => (
+        eachElement.user.login === key
+      ));
+    }
+
+    return parsedPRSet;
+  }
+
+  /* 
+   * reports a list of PR base on the input array of github PR json objects
+   */
+  reportPRList( dataPR ) {
+    if( dataPR === undefined ) {
+      return(
+        <div><h3>Array was undefined</h3></div>
+      );
+    }
+
+    if( dataPR.length === 0 ) {
+      return(
+        <div><h3>Found no data</h3></div>
+      );
+    }
+
     return(
-        this.state.githubPRsData.map( eachElement => (
+        dataPR.map( eachElement => (
           <div key={eachElement.id}>
             <h3><a href={eachElement.url}>{eachElement.id}</a></h3>
             <p>{eachElement.title}</p>
@@ -120,12 +147,24 @@ class App extends Component {
   }
 
   /* 
-   * reports a list of PR and their merge status
+   * reports a list of PR and their merge status base on the input array of github PR json objects
    */
-  reportPRListDetailed() {
+  reportPRListDetailed( dataPR ) {
+    if( dataPR === undefined ) {
+      return(
+        <div><h3>Array was undefined</h3></div>
+      );
+    }
+
+    if( dataPR.length === 0 ) {
+      return(
+        <div><h3>Found no data</h3></div>
+      );
+    }
+
     var githubPRsDataDetailed;
 
-    githubPRsDataDetailed = this.state.githubPRsData.map(
+    githubPRsDataDetailed = dataPR.map(
       eachElement => (
           <div key={eachElement.id}>
             <h3><a href={eachElement.url}> {eachElement.id} </a></h3>
@@ -156,10 +195,13 @@ class App extends Component {
         <div className="PRs">
           <input className={(this.state.error ? 'Warning' : '')} type="text" placeholder="opensource-ny/OpenSource-NY" onChange={this.handleRepoChange.bind(this)} onKeyPress={this.handleKeyPress.bind(this)}></input>
           <input type="submit" disabled={this.state.error} onClick={this.handleRepoSubmit.bind(this)}></input>  {/* Also make it on enter key */}
-        
+          
+
           {this.state.loading ? <h2>loading ...</h2> : ''}
           {this.state.error ? <h2>{this.state.error.message}</h2> : ''}
-          {this.reportPRListDetailed()}
+          {/* this.reportPRList(this.state.githubPRsData) */}
+          {/* this.reportPRListDetailed(this.state.githubPRsData) */}
+          {this.reportPRListDetailed( this.parseGithubPRJson(this.state.githubPRsData, 'byName', 'yizongk') )}
 
         </div>
 

--- a/myapp/client/src/App.js
+++ b/myapp/client/src/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import './App.css';
 import HeaderImg from './Components/Header'
-import ToUse from './Components/Summary'
+import HeaderSummary from './Components/Summary'
 
 class App extends Component {
   state = {
@@ -13,13 +13,9 @@ class App extends Component {
     githubPRsData: []
   }
 
-  resetState() {
+  resetFetchData() {
     this.setState({
       data: null,
-      repoName: '',
-      githubUserName: '',       
-      error: null,
-      loading: false,
       githubPRsData: []
     })
   }
@@ -80,6 +76,7 @@ class App extends Component {
   }
 
   handleRepoSubmit() {
+    this.resetFetchData();
     this.setState({ loading: true });
 
     fetch(`https://api.github.com/repos/${this.state.repoName}/pulls?state=all`).then(response => {
@@ -104,9 +101,15 @@ class App extends Component {
 
   /* parse an array of json objects describing PR from github based on a condition
    * returns an array of json objects based on condition
+   * returns the exact array as original if none of the condition matches
+   * if key is undefined or null or empty string, return the original array as it is
    */
   parseGithubPRJson( githubPRJsonSet, condition, key ) {
     var parsedPRSet = [];
+
+    if( key === undefined || key === null || key === '' ) {
+      return githubPRJsonSet;
+    }
 
     if( condition === 'byName' ) {
       parsedPRSet = githubPRJsonSet.filter( eachElement => (
@@ -206,13 +209,21 @@ class App extends Component {
         {/* Render the newly fetched data insdie of this.state.data */}
         <p className="App-intro">Something here:{this.state.data}</p>
 
-        <ToUse/>
+        <HeaderSummary/>
 
         <div className="PRs">
           <input className={(this.state.error ? 'Warning' : 'inputbox')} 
             name="repoName"
             type="text" 
-            placeholder="Enter information here" 
+            placeholder="Enter Github repository name here" 
+            onChange={this.handleInputChange.bind(this)} 
+            onKeyPress={this.handleKeyPress.bind(this)}>
+          </input>
+
+          <input className={(this.state.error ? 'Warning' : 'inputbox')} 
+            name="githubUserName"
+            type="text" 
+            placeholder="Enter Github username here" 
             onChange={this.handleInputChange.bind(this)} 
             onKeyPress={this.handleKeyPress.bind(this)}>
           </input>
@@ -231,7 +242,7 @@ class App extends Component {
           {this.state.error ? <h2>{this.state.error.message}</h2> : ''}
           {/* this.reportPRList(this.state.githubPRsData) */}
           {/* this.reportPRListDetailed(this.state.githubPRsData) */}
-          {this.reportPRListDetailed( this.parseGithubPRJson(this.state.githubPRsData, 'byName', 'yizongk') )}
+          {this.reportPRListDetailed( this.parseGithubPRJson(this.state.githubPRsData, 'byName', this.state.githubUserName) )}
 
         </div>
 

--- a/myapp/client/src/App.js
+++ b/myapp/client/src/App.js
@@ -68,6 +68,17 @@ class App extends Component {
     
   }
 
+  handleInputChange(event) {
+    if( event.target.name === 'repoName' ) {
+      this.handleRepoChange(event);
+      return;
+    }
+
+    this.setState({
+      [event.target.name]: event.target.value
+    });
+  }
+
   handleRepoSubmit() {
     this.setState({ loading: true });
 
@@ -199,9 +210,10 @@ class App extends Component {
 
         <div className="PRs">
           <input className={(this.state.error ? 'Warning' : 'inputbox')} 
+            name="repoName"
             type="text" 
             placeholder="Enter information here" 
-            onChange={this.handleRepoChange.bind(this)} 
+            onChange={this.handleInputChange.bind(this)} 
             onKeyPress={this.handleKeyPress.bind(this)}>
           </input>
 

--- a/myapp/client/src/App.js
+++ b/myapp/client/src/App.js
@@ -195,7 +195,7 @@ class App extends Component {
         <div className="PRs">
           <input className={(this.state.error ? 'Warning' : '')} type="text" placeholder="opensource-ny/OpenSource-NY" onChange={this.handleRepoChange.bind(this)} onKeyPress={this.handleKeyPress.bind(this)}></input>
           <input type="submit" disabled={this.state.error} onClick={this.handleRepoSubmit.bind(this)}></input>  {/* Also make it on enter key */}
-          
+          {/* make second submit for name, and if name and repo are entered, filter it. else just do repo. and don't allow submit if only name is filled in */}
 
           {this.state.loading ? <h2>loading ...</h2> : ''}
           {this.state.error ? <h2>{this.state.error.message}</h2> : ''}

--- a/myapp/client/src/App.js
+++ b/myapp/client/src/App.js
@@ -235,13 +235,9 @@ class App extends Component {
             onClick={this.handleRepoSubmit.bind(this)}>
           </input> 
 
-          {/* make second submit for name, and if name and repo are entered, filter it. else just do repo. and don't allow submit if only name is filled in */}
-
-        
           {this.state.loading ? <h2>loading ...</h2> : ''}
           {this.state.error ? <h2>{this.state.error.message}</h2> : ''}
-          {/* this.reportPRList(this.state.githubPRsData) */}
-          {/* this.reportPRListDetailed(this.state.githubPRsData) */}
+          {/* In the future, should only update output when submit button is hit or enter key is hit on input field. As of right now it constantly updates, which may not be good for us. */}
           {this.reportPRListDetailed( this.parseGithubPRJson(this.state.githubPRsData, 'byName', this.state.githubUserName) )}
 
         </div>

--- a/myapp/client/src/Components/Summary.js
+++ b/myapp/client/src/Components/Summary.js
@@ -19,6 +19,11 @@ function Opening(){
                 <strong>Example:</strong> opensource-ny/OpenSource-NY
             </p>
 
+            <p className="instructions">
+                Optional: Enter a Github username for Pull Requests maded by the specified username
+                if username doesn't exists, the outputs will be as if the username wasn't entered.
+            </p>
+
         </div>
     )
 }


### PR DESCRIPTION
an unexpected behavior that might work in our favor:

After you submit a repo name, entering any  username in the username input field, will automatically parse the entire repo's PR for PR that was created by that user. This action doesn't require fetching from github api again.  May or may not be in our benefit.